### PR TITLE
Add compatibility with python 3

### DIFF
--- a/doi-doai-openaccess.py
+++ b/doi-doai-openaccess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8  -*-
 """
 Queries the Wikimedia projects database replica on labsdb to list all
@@ -7,54 +7,108 @@ Requires Wikimedia Labs labsdb local access.
 
 Usage:
     doi-doai-openaccess.py --help
-    doi-doai-openaccess.py [--depositable] [--oadoi] [--list=FILE | <dbname>]
+    doi-doai-openaccess.py [--depositable] [--oadoi] [--dbcnf=DBCNF]
+                           [--list=FILE | <dbname>]
 
 Options:
     --help           Prints this documentation.
     --depositable    Lists closed access DOIs which could be deposited.
     --oadoi          Use the oaDOI API instead of DOAI.
     --list=FILE      Reads the DOIs from a text file rather than the database.
-    <dbname>         The dbname of the wiki to search DOIs in [default: enwiki].
+    --dbcnf=DBCNF    The configuration file with credentials
+                     [default: ~/.my.cnf]
+    <dbname>         The dbname of the wiki to search DOIs in
+                     [default: enwiki].
 
 Copyright waived (CC-0), Federico Leva, 2016–2017
 """
 
-import docopt
-import json
-from codecs import open
-try:
-    import MySQLdb
-except:
-    print( "WARNING: Cannot query the DB, MySQLdb isn't available" )
+from __future__ import absolute_import, division, print_function, \
+                       unicode_literals
+
+import os
 import random
 import re
-import requests
+import sys
 import time
-import urllib
+from contextlib import contextmanager
+from codecs import open
 
-session = requests.Session()
-sessiondoai = requests.Session()
+import docopt
+import requests
+import pymysql as dbclient
+
+if sys.version_info >= (3,):
+    from urllib.parse import unquote
+else:
+    from urllib import unquote
+
+SESSION = requests.Session()
+SESSIONDOAI = requests.Session()
 try:
     from requests.packages.urllib3.util.retry import Retry
     from requests.adapters import HTTPAdapter
     # Courtesy datashaman https://stackoverflow.com/a/35504626
-    retries = Retry(total=5,
-                    backoff_factor=2,
-                    status_forcelist=[ 500, 502, 503, 504 ])
-    session.mount('https://', HTTPAdapter(max_retries=retries))
+    __retries__ = Retry(total=5,
+                        backoff_factor=2,
+                        status_forcelist=[500, 502, 503, 504])
+    SESSION.mount('https://', HTTPAdapter(max_retries=__retries__))
 except:
     # Our urllib3/requests is too old
     pass
 
-def main(argv=None):
 
+@contextmanager
+def get_connection(wiki, dbcnf):
+    """ Create a connection object to a database:
+        * dbname: {wiki}.labsdb
+        * hostname: {wiki}_p
+        * default_file: {dbcnf}
+    """
+
+    if sys.version_info >= (3,):
+        # https://bugs.mysql.com/bug.php?id=84389
+        connection = dbclient.connect(host=wiki + '.labsdb',
+                                      db=wiki + '_p',
+                                      read_default_file=dbcnf)
+        # connection is <class 'pymysql.connections.Connection'>
+
+    else:
+        connection = dbclient.connect(host=wiki + '.labsdb',
+                                      db=wiki + '_p',
+                                      read_default_file=dbcnf)
+        # connection is <class 'MySQLdb.connections.Connection'>
+
+    assert isinstance(connection, dbclient.connections.Connection)
+
+    try:
+        yield connection
+    except Exception:
+        connection.rollback()
+        raise
+    else:
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def main(argv=None):
+    """ Queries the Wikimedia projects database replica on labsdb to list all
+        links to DOI documents which are Open Access on DOAI and Dissem.in.
+    """
     args = docopt.docopt(__doc__, argv=argv)
+
+    # default does not seem to work properly
+    if args['<dbname>'] is None:
+        args['<dbname>'] = 'enwiki'
+
     wiki = args['<dbname>']
+    dbcnf = os.path.abspath(os.path.expanduser(args['--dbcnf']))
 
     if args['--list']:
         doilist = open(args['--list'], 'r', encoding='utf-8').readlines()
     else:
-        doilist = get_doi_el(wiki) + get_doi_iwl(wiki)
+        doilist = get_doi_el(wiki, dbcnf).union(get_doi_iwl(wiki, dbcnf))
 
     if args['--depositable'] and not args['--oadoi']:
         for doi in doilist:
@@ -62,20 +116,22 @@ def main(argv=None):
             try:
                 archived = get_dissemin_pdf(doi)
                 if archived:
-                    print( u"URL available for DOI: %s" % doi)
+                    print(u"URL available for DOI: {}".format(doi))
                 else:
                     archived = get_doai_oa(doi)
                     if archived:
                         if re.search('academia.edu', archived):
-                            print( u"Social URL available for DOI: %s" % doi )
+                            print(u"Social URL available for DOI: {}"
+                                  .format(doi))
                             archived = None
                         else:
-                            print( u"URL available for DOI: http://doai.io/%s" % doi )
+                            print(u"URL available for DOI: http://doai.io/{}"
+                                  .format(doi))
 
                 if not archived and is_depositable(doi):
-                        print( u"Depositable DOI: %s" % doi )
+                    print(u"Depositable DOI: {}".format(doi))
                 else:
-                        print( u"Non-depositable DOI: %s" % doi )
+                    print(u"Non-depositable DOI: {}".format(doi))
             except:
                 continue
     elif args['--depositable'] and args['--oadoi']:
@@ -83,24 +139,25 @@ def main(argv=None):
             try:
                 doi = doi.strip()
                 if get_oadoi(doi):
-                    print( u"URL available in oaDOI for DOI: %s" % doi )
+                    print(u"URL available in oaDOI for DOI: {}".format(doi))
                 else:
                     if is_depositable(doi):
-                        print( u"Depositable DOI: %s" % doi )
+                        print(u"Depositable DOI: {}".format(doi))
                     else:
-                        print( u"Non-depositable DOI: %s" % doi )
+                        print(u"Non-depositable DOI: {}".format(doi))
             except:
                 continue
     else:
         for doi in doilist:
             if args['--oadoi']:
                 if get_oadoi(doi):
-                    print( doi )
+                    print(doi)
             else:
                 if get_doai_oa(doi):
-                    print( doi )
+                    print(doi)
 
-def get_doi_el(wiki):
+
+def get_doi_el(wiki, dbcnf):
     """ Set of DOI codes from external links. """
 
     dois = set([])
@@ -110,23 +167,22 @@ def get_doi_el(wiki):
     WHERE el_index LIKE 'https://org.doi.dx./10%'
     OR el_index LIKE 'http://org.doi.dx./10%'"""
 
-    connection = MySQLdb.connect(host=wiki + '.labsdb',
-                                 db=wiki + '_p',
-                                 read_default_file='~/.my.cnf')
-    cursor = connection.cursor()
-    cursor.execute(doiquery)
-    for link in cursor.fetchall():
-        try:
-            doi = re.findall('10.+$', link[0])[0]
-            if doi:
-                dois.add(urllib.unquote(doi))
-        except IndexError:
-            continue
+    with get_connection(wiki, dbcnf) as connection:
+        cursor = connection.cursor()
+        cursor.execute(doiquery)
+        for link in cursor.fetchall():
+            try:
+                doi = re.findall('10.+$', link[0].decode('utf-8'))[0]
+                if doi:
+                    dois.add(unquote(doi))
+            except IndexError:
+                continue
 
     # print "Found %d DOI external links on %s" % (len(dois), wiki)
     return dois
 
-def get_doi_iwl(wiki):
+
+def get_doi_iwl(wiki, dbcnf):
     """ Set of DOI codes from interwiki links. """
 
     dois = set([])
@@ -136,22 +192,23 @@ def get_doi_iwl(wiki):
     WHERE iwl_prefix = 'doi'
     AND iwl_title LIKE '10%'"""
 
-    connection = MySQLdb.connect(host=wiki + '.labsdb',
-                                 db=wiki + '_p',
-                                 read_default_file='~/.my.cnf')
-    cursor = connection.cursor()
-    cursor.execute(doiquery)
-    for link in cursor.fetchall():
-        dois.add(link[0])
+    with get_connection(wiki, dbcnf) as connection:
+        cursor = connection.cursor()
+        cursor.execute(doiquery)
+        for link in cursor.fetchall():
+            dois.add(link[0])
 
     return dois
 
-def get_doai_oa(doi):
-    """ Given a DOI, return DOAI target URL if green open access, None otherwise. """
 
-    doaiurl = 'http://doai.io/%s' % doi
+def get_doai_oa(doi):
+    """ Given a DOI, return DOAI target URL if green open access,
+        None otherwise.
+    """
+
+    doaiurl = 'http://doai.io/{}'.format(doi)
     try:
-        doai = sessiondoai.head(url=doaiurl)
+        doai = SESSIONDOAI.head(url=doaiurl)
     except requests.ConnectionError:
         time.sleep(random.randint(1, 100))
         return False
@@ -163,29 +220,34 @@ def get_doai_oa(doi):
         else:
             return url
 
+
 def get_oadoi(doi):
-    """ Given a DOI, return oaDOI target URL if open access, None otherwise. """
+    """ Given a DOI, return oaDOI target URL if open access,
+        None otherwise.
+    """
 
     try:
-        oadoi = sessiondoai.get("https://api.oadoi.org/%s?email=openaccess@wikimedia.it" % doi)
+        oadoi = SESSIONDOAI.get("https://api.oadoi.org/{}"
+                                "?email=openaccess@wikimedia.it"
+                                .format(doi))
         oadoi = oadoi.json()['results'][0]
     except:
         time.sleep(random.randint(1, 100))
         return False
 
-    if 'free_fulltext_url' in oadoi:
-        return oadoi['free_fulltext_url']
-    else:
-        return None
+    return oadoi.get('free_fulltext_url', None)
+
 
 def get_dissemin_pdf(doi):
-    """ Given a DOI, return the first URL which Dissemin believes to provide a PDF """
+    """ Given a DOI, return the first URL which Dissemin believes to provide
+        a PDF
+    """
 
     try:
-        r = session.get('https://dissem.in/api/%s' % doi)
-        if r.status_code >= 400:
+        req = SESSION.get('https://dissem.in/api/%s' % doi)
+        if req.status_code >= 400:
             return None
-        for record in r.json()['paper']['records']:
+        for record in req.json()['paper']['records']:
             if 'pdf_url' in record:
                 return record['pdf_url']
     except:
@@ -193,19 +255,20 @@ def get_dissemin_pdf(doi):
 
     return
 
+
 def is_depositable(doi):
-    # JSON requires 2.4.2 http://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests
-    payload = '{"doi": "%s"}' % doi
+    # JSON requires 2.4.2
+    # http://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests
+    payload = '{{ "doi": "{}" }}'.format(doi)
+    req = SESSION.post('https://dissem.in/api/query', data=payload)
+    if req.status_code >= 400:
+        print(u"ERROR with: {}".format(doi))
+        return None
     try:
-        r = session.post('https://dissem.in/api/query', data=payload)
-        if r.status_code >= 400:
-            print( u"ERROR with: %s" % doi )
-            return None
-        dis = r.json()
-        if dis['status'] == "ok" and 'classification' in dis['paper'] and ( dis['paper']['classification'] == "OK" or dis['paper']['classification'] == "OA" ):
-            return True
-        else:
-            return False
+        dis = req.json()
+        return dis['status'] == "ok" and 'classification' in dis['paper'] \
+            and (dis['paper']['classification'] == "OK" or
+                 dis['paper']['classification'] == "OA")
     except:
         return None
 


### PR DESCRIPTION
This script now supports both Python 2 (tested with v. `2.7.6`) and Python 3 (tested with v. `3.4.3`).

I have factored out a function establishing the connection with the database and used a library (`pymysql`), which can be installed with `pip2` and `pip3`) that supports both Python 2 and 3.

I have added a new optional argument to specify the location of the MySQL defaults file.

Finally, I have cleaned up the script according to the Python's style guidelines (PEP8).